### PR TITLE
Adjust expected HTTP status code on create acl

### DIFF
--- a/cmd/stackit-secrets-manager/cmd/createAcl.go
+++ b/cmd/stackit-secrets-manager/cmd/createAcl.go
@@ -47,7 +47,7 @@ func createAcl() error {
 	if err != nil {
 		return fmt.Errorf("failed to create acl: %w", err)
 	}
-	if response.StatusCode != http.StatusOK {
+	if response.StatusCode != http.StatusCreated {
 		return fmt.Errorf("unexpected status code: %s", response.Status)
 	}
 


### PR DESCRIPTION
CLI returns: `ERROR: unexpected status code: 201 Created`, if creating acl rules successfully. According to api docs, a 201 is returned.